### PR TITLE
Makefile: add make targets for easy libpod tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,100 +1,28 @@
-.PHONY: all
-all: test
+# The DOCKER_HOST endpoint
+ENDPOINT ?= tcp://localhost:8080
 
-.PHONY: clean
-clean:
-	-docker rm -f dpy-dind-py2 dpy-dind-py3 dpy-dind-certs dpy-dind-ssl
-	find -name "__pycache__" | xargs rm -rf
+CTR_IMAGE ?= quay.io/libpod/docker-py:latest
+CTR_ENGINE ?= podman
+CTR_COMMAND = run --rm --security-opt label=disable --privileged \
+	      	-v $(testLogs):/testLogs --net=host -e DOCKER_HOST=$(ENDPOINT)
 
-.PHONY: build
-build:
-	docker build -t docker-sdk-python -f tests/Dockerfile --build-arg PYTHON_VERSION=2.7 --build-arg APT_MIRROR .
-
-.PHONY: build-py3
-build-py3:
-	docker build -t docker-sdk-python3 -f tests/Dockerfile --build-arg APT_MIRROR .
-
-.PHONY: build-docs
-build-docs:
-	docker build -t docker-sdk-python-docs -f Dockerfile-docs --build-arg uid=$(shell id -u) --build-arg gid=$(shell id -g) .
-
-.PHONY: build-dind-certs
-build-dind-certs:
-	docker build -t dpy-dind-certs -f tests/Dockerfile-dind-certs .
-
-.PHONY: test
-test: flake8 unit-test unit-test-py3 integration-dind integration-dind-ssl
-
-.PHONY: unit-test
-unit-test: build
-	docker run -t --rm docker-sdk-python py.test tests/unit
-
-.PHONY: unit-test-py3
-unit-test-py3: build-py3
-	docker run -t --rm docker-sdk-python3 py.test tests/unit
-
-.PHONY: integration-test
-integration-test: build
-	docker run -t --rm -v /var/run/docker.sock:/var/run/docker.sock docker-sdk-python py.test -v tests/integration/${file}
-
-.PHONY: integration-test-py3
-integration-test-py3: build-py3
-	docker run -t --rm -v /var/run/docker.sock:/var/run/docker.sock docker-sdk-python3 py.test -v tests/integration/${file}
-
-TEST_API_VERSION ?= 1.35
-TEST_ENGINE_VERSION ?= 18.09.5
-
-.PHONY: setup-network
-setup-network:
-	docker network inspect dpy-tests || docker network create dpy-tests
-
-.PHONY: integration-dind
-integration-dind: integration-dind-py2 integration-dind-py3
-
-.PHONY: integration-dind-py2
-integration-dind-py2: build setup-network
-	docker rm -vf dpy-dind-py2 || :
-	docker run -d --network dpy-tests --name dpy-dind-py2 --privileged\
-		dockerswarm/dind:${TEST_ENGINE_VERSION} dockerd -H tcp://0.0.0.0:2375 --experimental
-	docker run -t --rm --env="DOCKER_HOST=tcp://dpy-dind-py2:2375" --env="DOCKER_TEST_API_VERSION=${TEST_API_VERSION}"\
-		--network dpy-tests docker-sdk-python py.test tests/integration
-	docker rm -vf dpy-dind-py2
-
-.PHONY: integration-dind-py3
-integration-dind-py3: build-py3 setup-network
-	docker rm -vf dpy-dind-py3 || :
-	docker run -d --network dpy-tests --name dpy-dind-py3 --privileged\
-		dockerswarm/dind:${TEST_ENGINE_VERSION} dockerd -H tcp://0.0.0.0:2375 --experimental
-	docker run -t --rm --env="DOCKER_HOST=tcp://dpy-dind-py3:2375" --env="DOCKER_TEST_API_VERSION=${TEST_API_VERSION}"\
-		--network dpy-tests docker-sdk-python3 py.test tests/integration
-	docker rm -vf dpy-dind-py3
-
-.PHONY: integration-dind-ssl
-integration-dind-ssl: build-dind-certs build build-py3
-	docker rm -vf dpy-dind-certs dpy-dind-ssl || :
-	docker run -d --name dpy-dind-certs dpy-dind-certs
-	docker run -d --env="DOCKER_HOST=tcp://localhost:2375" --env="DOCKER_TLS_VERIFY=1"\
-		--env="DOCKER_CERT_PATH=/certs" --volumes-from dpy-dind-certs --name dpy-dind-ssl\
-		--network dpy-tests --network-alias docker -v /tmp --privileged\
-		dockerswarm/dind:${TEST_ENGINE_VERSION}\
-		dockerd --tlsverify --tlscacert=/certs/ca.pem --tlscert=/certs/server-cert.pem\
-		--tlskey=/certs/server-key.pem -H tcp://0.0.0.0:2375 --experimental
-	docker run -t --rm --volumes-from dpy-dind-ssl --env="DOCKER_HOST=tcp://docker:2375"\
-		--env="DOCKER_TLS_VERIFY=1" --env="DOCKER_CERT_PATH=/certs" --env="DOCKER_TEST_API_VERSION=${TEST_API_VERSION}"\
-		--network dpy-tests docker-sdk-python py.test tests/integration
-	docker run -t --rm --volumes-from dpy-dind-ssl --env="DOCKER_HOST=tcp://docker:2375"\
-		--env="DOCKER_TLS_VERIFY=1" --env="DOCKER_CERT_PATH=/certs" --env="DOCKER_TEST_API_VERSION=${TEST_API_VERSION}"\
-		--network dpy-tests docker-sdk-python3 py.test tests/integration
-	docker rm -vf dpy-dind-ssl dpy-dind-certs
-
-.PHONY: flake8
-flake8: build
-	docker run -t --rm docker-sdk-python flake8 docker tests
-
-.PHONY: docs
-docs: build-docs
-	docker run --rm -t -v `pwd`:/src docker-sdk-python-docs sphinx-build docs docs/_build
+.PHONY: build-container-image
+build-container-image:
+	$(CTR_ENGINE) build -t $(CTR_IMAGE) -f ./Dockerfile-py3 .
 
 .PHONY: shell
-shell: build
-	docker run -it -v /var/run/docker.sock:/var/run/docker.sock docker-sdk-python python
+shell:
+	@echo "Connecting to $(ENDPOINT)"
+	$(eval testLogs=$(shell mktemp))
+	@echo "Test logs at $(testLogs)"
+	@echo "Note that PWD is mounted at /src."
+	$(CTR_ENGINE) $(CTR_COMMAND) -v `pwd`:/src -it $(CTR_IMAGE) sh
+
+.PHONY: test
+test:
+	@echo "Connecting to $(ENDPOINT)"
+	$(eval testLogs=$(shell mktemp))
+	@echo "Test logs at $(testLogs)"
+	@echo "Use the TEST env var to control which tests are being run, for instance:"
+	@echo "    DOCKERPY_TEST="tests/integration/api_container_test.py::ListContainersTest"
+	$(CTR_ENGINE) $(CTR_COMMAND) $(CTR_IMAGE) sh -c "pytest $(TEST)"


### PR DESCRIPTION
- `make build-container-image` for building the
  `quay.io/libpod/docker-py:latest` image

- `make shell` to run the container and get a shell

- `make test` to run pytest in the container

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>